### PR TITLE
Fix for clearHistory() function throwing a threading exception

### DIFF
--- a/ORLib/src/main/java/io/openremote/orlib/ui/OrMainActivity.kt
+++ b/ORLib/src/main/java/io/openremote/orlib/ui/OrMainActivity.kt
@@ -40,6 +40,7 @@ import io.openremote.orlib.service.QrScannerProvider
 import io.openremote.orlib.shared.SharedData.offlineActivity
 import org.json.JSONException
 import org.json.JSONObject
+import java.lang.Exception
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -592,8 +593,18 @@ open class OrMainActivity : Activity() {
                 }
 
                 "CLEAR_WEB_HISTORY" -> {
+                    handleClearHistoryMessage()
+                }
+            }
+        }
+
+        private fun handleClearHistoryMessage() {
+            try {
+                binding.webView.post {
                     binding.webView.clearHistory()
                 }
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
         }
 


### PR DESCRIPTION
During the web implementation for this functionality, I came across an threading error when
trying to clear the browser history. See here;
```
java.lang.RuntimeException: java.lang.Throwable: A WebView method was called on thread 'JavaBridge'. All WebView methods must be called on the same thread. (Expected Looper Looper (main, tid 2) {81e2ca1} called on Looper (JavaBridge, tid 10219) {e0810de}, FYI main Looper is Looper (main, tid 2) {81e2ca1})
```

I did a quick google search and adjusted the code. Was working on my local Android device.
Also discussed this shortly with @Miggets7 on Skype.

Feel free to review 👍 