### PR TITLE
Publish using Central Portal

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ systemProp.org.gradle.internal.repository.max.retries=10
 # the initial time before retrying, in milliseconds (default 125)
 systemProp.org.gradle.internal.repository.initial.backoff=500
 
-snapshotsRepoUrl=https://s01.oss.sonatype.org/content/repositories/snapshots/
-releasesRepoUrl=https://s01.oss.sonatype.org/service/local/
+snapshotsRepoUrl=https://central.sonatype.com/repository/maven-snapshots/
+releasesRepoUrl=https://ossrh-staging-api.central.sonatype.com/service/local/


### PR DESCRIPTION
OSSRH is reaching end of life on June 30, 2025. OSSRH users need to migrate their namespaces to the Central Portal as soon as possible.

Instructions for self migration are located here: https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration

Manual steps to complete the migration:

1. Migrate io.openremote namespace to Central Portal (https://central.sonatype.com/publishing/namespaces)
2. Generate a new user token (https://central.sonatype.com/account) and use it to update the `_TEMP_MAVEN_USERNAME` and `_TEMP_MAVEN_PASSWORD` GitHub Actions secrets

See also:

* https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
* https://github.com/gradle-nexus/publish-plugin/issues/330

Related to openremote/openremote#1858