### PR TITLE
Fix .DS_Store macOS file not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ bin-release/
 .vscode/
 .idea/
 .local/
-.DS_*/
+.DS_*
 
 # File extensions
 *.apk


### PR DESCRIPTION
The .gitignore file doesn't exclude `.DS_Store` files because it checks for a directory instead of a file. Removing the `/` at the end solves this issue.