### PR TITLE
Publish protobuf JavaDocs

### DIFF
--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -7,6 +7,11 @@ plugins {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+    withJavadocJar()
+}
+
+javadoc {
+    failOnError = false
 }
 
 apply plugin: 'com.google.protobuf'


### PR DESCRIPTION
It's required in the Maven Central validation:

```
> Task :closeSonatypeStagingRepository FAILED
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':closeSonatypeStagingRepository'.
> Failed to close staging repository, server at https://ossrh-staging-api.central.sonatype.com/service/local/ responded with status code 400, body: Failed to process request: Deployment reached an unexpected status: Failed
  pkg:maven/io.openremote/orlib-protobuf@1.4.1
  - Javadocs must be provided but not found in entries

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 2m 23s
```