### PR TITLE
Use axion-release-plugin v1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
 plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
-    id 'pl.allegro.tech.build.axion-release' version '1.18.16'
+    id 'pl.allegro.tech.build.axion-release' version '1.21.1'
 }
 
 scmVersion {


### PR DESCRIPTION
This version supports the actions/checkout@v6 credential storage mechanism which fixes "not authorized" exceptions.
