### PR TITLE
ESPProvision/Add dynamic `properties` field to `ORConfigChannelProtocol`

### DIFF
--- a/ORLib/src/main/java/io/openremote/orlib/service/espprovision/DeviceConnection.kt
+++ b/ORLib/src/main/java/io/openremote/orlib/service/espprovision/DeviceConnection.kt
@@ -101,7 +101,8 @@ class DeviceConnection(val deviceRegistry: DeviceRegistry, var callbackChannel: 
         mqttBrokerUrl: String,
         mqttUser: String,
         mqttPassword: String,
-        assetId: String
+        assetId: String,
+        properties: Map<String, String> = emptyMap()
     ) {
         if (!isConnected) {
             throw ESPProviderException(
@@ -114,7 +115,8 @@ class DeviceConnection(val deviceRegistry: DeviceRegistry, var callbackChannel: 
                 mqttBrokerUrl = mqttBrokerUrl,
                 mqttUser = mqttUser,
                 mqttPassword = mqttPassword,
-                assetId = assetId
+                assetId = assetId,
+                properties = properties
             )
         } catch (e: Exception) {
             throw ESPProviderException(

--- a/ORLib/src/main/java/io/openremote/orlib/service/espprovision/DeviceProvision.kt
+++ b/ORLib/src/main/java/io/openremote/orlib/service/espprovision/DeviceProvision.kt
@@ -34,14 +34,15 @@ class DeviceProvision(var deviceConnection: DeviceConnection?, var callbackChann
 
             val password = generatePassword()
 
-            val assetId = deviceProvisionAPI.provision(deviceInfo.modelName, deviceInfo.deviceId, password, userToken)
+            val result = deviceProvisionAPI.provision(deviceInfo.modelName, deviceInfo.deviceId, password, userToken)
             val userName = deviceInfo.deviceId.lowercase(Locale("en"))
 
             deviceConnection?.sendOpenRemoteConfig(
                 mqttBrokerUrl = mqttURL,
                 mqttUser = userName,
                 mqttPassword = password,
-                assetId = assetId
+                assetId = result.assetId,
+                properties = result.properties
             )
 
             var status = BackendConnectionStatus.CONNECTING

--- a/ORLib/src/main/java/io/openremote/orlib/service/espprovision/DeviceProvisionAPI.kt
+++ b/ORLib/src/main/java/io/openremote/orlib/service/espprovision/DeviceProvisionAPI.kt
@@ -13,8 +13,13 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 interface DeviceProvisionAPI {
-    suspend fun provision(modelName: String, deviceId: String, password: String, token: String): String
+    suspend fun provision(modelName: String, deviceId: String, password: String, token: String): ProvisionResult
 }
+
+data class ProvisionResult(
+    val assetId: String,
+    val properties: Map<String, String>
+)
 
 class DeviceProvisionAPIREST(private val apiURL: URL) : DeviceProvisionAPI {
 
@@ -22,7 +27,7 @@ class DeviceProvisionAPIREST(private val apiURL: URL) : DeviceProvisionAPI {
         private const val TAG = "DeviceProvisionAPIREST"
     }
 
-    override suspend fun provision(modelName: String, deviceId: String, password: String, token: String): String = withContext(Dispatchers.IO) {
+    override suspend fun provision(modelName: String, deviceId: String, password: String, token: String): ProvisionResult = withContext(Dispatchers.IO) {
         Log.d(ESPProvisionProvider.TAG, "apiURL $apiURL")
         val uri = Uri.parse(apiURL.toString()).buildUpon()
             .appendPath("rest")
@@ -65,7 +70,15 @@ class DeviceProvisionAPIREST(private val apiURL: URL) : DeviceProvisionAPI {
             }
 
             val json = JSONObject(responseText)
-            return@withContext json.getString("assetId")
+            val assetId = json.getString("assetId")
+            val properties = mutableMapOf<String, String>()
+            if (json.has("properties") && !json.isNull("properties")) {
+                val propertiesJson = json.getJSONObject("properties")
+                propertiesJson.keys().forEach { key ->
+                    properties[key] = propertiesJson.getString(key)
+                }
+            }
+            return@withContext ProvisionResult(assetId = assetId, properties = properties)
         } catch (e: DeviceProvisionAPIError) {
             throw e
         } catch (e: Exception) {

--- a/ORLib/src/main/java/io/openremote/orlib/service/espprovision/ORConfigChannel.kt
+++ b/ORLib/src/main/java/io/openremote/orlib/service/espprovision/ORConfigChannel.kt
@@ -47,7 +47,8 @@ class ORConfigChannel(private val device: ESPDevice) {
         mqttUser: String,
         mqttPassword: String,
         realm: String = "master",
-        assetId: String
+        assetId: String,
+        properties: Map<String, String> = emptyMap()
     ) {
         val config = Request.OpenRemoteConfig.newBuilder()
             .setMqttBrokerUrl(mqttBrokerUrl)
@@ -55,6 +56,7 @@ class ORConfigChannel(private val device: ESPDevice) {
             .setMqttPassword(mqttPassword)
             .setAssetId(assetId)
             .setRealm(realm)
+            .putAllProperties(properties)
             .build()
 
         val request = Request.newBuilder()

--- a/protobuf/src/main/proto/ORConfigChannelProtocol.proto
+++ b/protobuf/src/main/proto/ORConfigChannelProtocol.proto
@@ -72,6 +72,7 @@ message Request {
         string mqtt_password = 3;
         string realm = 4;
         string asset_id = 5;
+        map<string, string> properties = 6;
     }
     message ExitProvisioning {};
     string id = 1;


### PR DESCRIPTION
Closes #53 

Adds a dynamic `properties` map to the `OpenRemoteConfig` proto message and wires it through from the `/rest/device` REST response. This lets us forward additional config values (e.g. OTA URL/token) to the device during BLE provisioning when the backend supplies them.

The field is fully optional end-to-end. If the REST response omits properties, nothing is added on the wire.
