### PR TITLE
Modernize Gradle dependency management

### DIFF
--- a/GenericApp/app/build.gradle
+++ b/GenericApp/app/build.gradle
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id 'com.android.application'
-    id 'com.google.gms.google-services'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.google.services)
     id 'maven-publish'
     id 'signing'
 }
@@ -68,24 +68,19 @@ kotlin {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.core:core-ktx:1.18.0'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'androidx.preference:preference-ktx:1.2.1'
-    implementation "com.google.android.gms:play-services-location:21.4.0"
-    // Pinned below 2.20: 2.20+ emits MethodHandle.invokeExact value-class bytecode
-    // that D8 rejects for minSdk < 26 (this project is minSdk 25). `strictly` makes a
-    // transitive bump to >=2.20 fail resolution loudly instead of silently breaking dexing.
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin") {
-        version { strictly '2.19.4' }
-    }
-    implementation platform('com.google.firebase:firebase-bom:34.16.0')
-    implementation 'com.google.firebase:firebase-messaging'
-    implementation 'com.google.android.material:material:1.14.0'
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.constraintlayout
+    implementation libs.androidx.preference.ktx
+    implementation libs.play.services.location
+    implementation libs.jackson.module.kotlin
+    implementation platform(libs.firebase.bom)
+    implementation libs.firebase.messaging
+    implementation libs.material
     implementation project(':ORLib')
 
     // Unit testing framework
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
 }
 
 tasks.register('sourcesJar', Jar) {

--- a/GenericApp/gradle/wrapper/gradle-wrapper.properties
+++ b/GenericApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Mon Jan 24 13:58:21 CET 2022
-distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
-distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME

--- a/ORLib/build.gradle
+++ b/ORLib/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id 'com.android.library'
+    alias(libs.plugins.android.library)
     id 'maven-publish'
     id 'signing'
 }
@@ -58,39 +58,34 @@ kotlin {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.18.0'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'com.google.android.material:material:1.14.0'
-    implementation 'androidx.preference:preference-ktx:1.2.1'
-    implementation "com.google.android.gms:play-services-location:21.4.0"
-    implementation 'com.google.android.gms:play-services-vision:20.1.3'
-    // Pinned below 2.20: 2.20+ emits MethodHandle.invokeExact value-class bytecode
-    // that D8 rejects for minSdk < 26 (this project is minSdk 25). `strictly` makes a
-    // transitive bump to >=2.20 fail resolution loudly instead of silently breaking dexing.
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin") {
-        version { strictly '2.19.4' }
-    }
-    implementation platform('com.google.firebase:firebase-bom:34.16.0')
-    implementation 'com.google.firebase:firebase-messaging'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.github.espressif:esp-idf-provisioning-android:lib-2.4.4'
-    implementation 'org.greenrobot:eventbus:3.3.1'
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.appcompat
+    implementation libs.material
+    implementation libs.androidx.preference.ktx
+    implementation libs.play.services.location
+    implementation libs.play.services.vision
+    implementation libs.jackson.module.kotlin
+    implementation platform(libs.firebase.bom)
+    implementation libs.firebase.messaging
+    implementation libs.androidx.constraintlayout
+    implementation libs.esp.idf.provisioning
+    implementation libs.eventbus
 
-    implementation 'com.google.protobuf:protobuf-javalite:4.35.1'
-    implementation('com.google.protobuf:protobuf-kotlin:4.35.1') {
+    implementation libs.protobuf.javalite
+    implementation(libs.protobuf.kotlin) {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0'
+    implementation libs.coroutines.core
+    implementation libs.coroutines.android
 
-    implementation 'com.github.iammohdzaki:Password-Generator:0.6'
+    implementation libs.password.generator
 
     api project(':orlib-protobuf')
 }
 
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
     archiveClassifier = 'sources'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,10 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    ext.kotlin_version = "2.4.10"
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:9.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.5.0'
-
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.10.0"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
 plugins {
-    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
-    id 'pl.allegro.tech.build.axion-release' version '1.21.2'
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.nexus.publish)
+    alias(libs.plugins.axion.release)
 }
 
 scmVersion {
@@ -53,12 +39,7 @@ nexusPublishing {
 }
 
 allprojects {
-    project.version = scmVersion.version
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = 'https://jitpack.io' }
-    }
+    project.version = rootProject.scmVersion.version
 }
 
 tasks.register('clean', Delete) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,53 @@
+[versions]
+agp = "9.3.0"
+androidx-appcompat = "1.7.1"
+androidx-constraintlayout = "2.2.1"
+androidx-core-ktx = "1.18.0"
+androidx-preference = "1.2.1"
+axion-release-plugin = "1.21.2"
+coroutines = "1.11.0"
+esp-idf-provisioning = "lib-2.4.4"
+eventbus = "3.3.1"
+firebase-bom = "34.16.0"
+google-services-plugin = "4.5.0"
+# Jackson is pinned below 2.20: 2.20+ emits MethodHandle.invokeExact value-class bytecode
+# that D8 rejects for minSdk < 26 (this project is minSdk 25). The catalog's
+# strict version makes a transitive bump fail resolution instead of breaking dexing.
+jackson = { strictly = "2.19.4" }
+junit = "4.13.2"
+material = "1.14.0"
+nexus-publish-plugin = "2.0.0"
+password-generator = "0.6"
+play-services-location = "21.4.0"
+play-services-vision = "20.1.3"
+protobuf = "4.35.1"
+protobuf-plugin = "0.10.0"
+
+[libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
+androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+esp-idf-provisioning = { module = "com.github.espressif:esp-idf-provisioning-android", version.ref = "esp-idf-provisioning" }
+eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+junit = { module = "junit:junit", version.ref = "junit" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+password-generator = { module = "com.github.iammohdzaki:Password-Generator", version.ref = "password-generator" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
+play-services-vision = { module = "com.google.android.gms:play-services-vision", version.ref = "play-services-vision" }
+protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protobuf" }
+protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf" }
+protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+axion-release = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion-release-plugin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services-plugin" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
+    alias(libs.plugins.protobuf)
 }
 
 java {
@@ -14,11 +15,9 @@ javadoc {
     failOnError = false
 }
 
-apply plugin: 'com.google.protobuf'
-
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:4.35.1"
+        artifact = libs.protobuf.protoc.get().toString()
     }
     generateProtoTasks {
         all().each { task ->
@@ -32,10 +31,10 @@ protobuf {
 }
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-javalite:4.35.1'
+    implementation libs.protobuf.javalite
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     dependsOn tasks.named('generateProto')
     from sourceSets.main.java.srcDirs
     archiveClassifier = 'sources'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,21 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri('https://jitpack.io') }
+    }
+}
+
 // Include sub-projects dynamically, every directory with a build.gradle (and no .buildignore)
 fileTree(dir: rootDir, include: "**/build.gradle")
         .filter { it.parent != rootDir }


### PR DESCRIPTION
* Migrate plugin and dependency versions to a Gradle version catalog
* Centralize dependency repositories in `settings.gradle`
* Upgrade the Android Gradle Plugin to 9.3.0
* Replace legacy plugin application and task declarations
* Preserve strict Jackson version constraints for Android API 25 compatibility
* Remove the obsolete nested Gradle wrapper